### PR TITLE
Add title checker

### DIFF
--- a/.github/github-title-checker-config.json
+++ b/.github/github-title-checker-config.json
@@ -1,0 +1,15 @@
+{
+    "LABEL": {
+      "name": "title needs formatting",
+      "color": "EEEEEE"
+    },
+    "CHECKS": {
+      "prefixes": ["close ", "closes ", "closed ", "fix ", "fixes ", "fixed ", "resolve ", "resolves ", "resolved "],
+      "regexp": "docs\\(v[0-9]\\): ",
+    },
+    "MESSAGES": {
+      "success": "All OK",
+      "failure": "Failing CI test",
+      "notice": ""
+    }
+  }

--- a/.github/workflows/title-checker.yaml
+++ b/.github/workflows/title-checker.yaml
@@ -1,0 +1,21 @@
+name: "PR Title Checker"
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.3.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: ".github/pr-title-checker-config.json"


### PR DESCRIPTION
When merging into main, an issue should be closed. Title should be checked whether it utilizes keywords to autoclose issues on merge.